### PR TITLE
adds basic skeleton to card

### DIFF
--- a/src/components/PersonCard/PersonCard.js
+++ b/src/components/PersonCard/PersonCard.js
@@ -1,0 +1,84 @@
+import React from "react";
+import { Card, CardContent, makeStyles, Typography } from "@material-ui/core";
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    display: "inline-flex",
+    height: "75vh",
+    width: "50vh",
+  },
+  content: {
+    width: "100%",
+    display: "flex",
+    flexDirection: "column",
+  },
+  header: {
+    textAlign: "center",
+  },
+  notHeader: {
+    flexGrow: "1",
+    display: "flex",
+    flexDirection: "column",
+  },
+  innerHeader: {
+    marginTop: "16px",
+  },
+  details: {
+    flexGrow: "1",
+    backgroundColor: "lightgrey", // SKELETON ONLY REMOVE
+    color: "white", // SKELETON ONLY REMOVE
+    height: "10px",
+    width: "100%",
+    overflow: "scroll",
+  },
+  summary: {
+    flexGrow: "2",
+    backgroundColor: "silver", // SKELETON ONLY REMOVE
+    color: "white", // SKELETON ONLY REMOVE
+    height: "10px",
+    width: "100%",
+    overflow: "scroll",
+  },
+}));
+
+/**
+ * TODO: Inherit details from props
+ */
+function PersonCard(props) {
+  const classes = useStyles();
+  return (
+    <Card className={classes.root}>
+      <CardContent className={classes.content}>
+        <Typography className={classes.header} component="h4">
+          Person Name
+        </Typography>
+        <div className={classes.notHeader}>
+          {/* Scrolling Details */}
+          <div className={classes.details}>details</div>
+
+          <Typography
+            className={`${classes.header} ${classes.innerHeader}`}
+            component="h4"
+          >
+            Summary
+          </Typography>
+
+          {/* Scrolling Summary */}
+          <div className={classes.summary}>
+            Summary <br /> Lorem ipsum dolor sit amet, consectetur adipiscing
+            elit. Curabitur id felis metus. Vestibulum et pulvinar tortor. Morbi
+            pharetra lacus ut ex molestie blandit. Etiam et turpis sit amet
+            risus mollis interdum. Suspendisse et justo vitae metus bibendum
+            fringilla sed sed justo. Aliquam sollicitudin dapibus lectus, vitae
+            consequat odio elementum eget. Praesent efficitur eros vitae nunc
+            interdum, eu interdum justo facilisis. Sed pulvinar nulla ac
+            dignissim efficitur. Quisque eget eros metus. Vestibulum bibendum
+            fringilla nibh a luctus. Duis a sapien metus.
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default PersonCard;


### PR DESCRIPTION
This card is a basic card to display a person's name, summary and any detail chips.
The details & summary are scrollable. Side overflow may need tweaks.
Cards are currently sized in vh (% of viewport height). I'm using this to maintain "card" shape, this keeps the aspect ratio since both width and height are relative to the user's viewport height.